### PR TITLE
Fix Windows preprocessor directive

### DIFF
--- a/src/core/JobManager.cpp
+++ b/src/core/JobManager.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <fmt/core.h>
 #include <csignal>
-#elif _WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 

--- a/src/core/MinerCore.cpp
+++ b/src/core/MinerCore.cpp
@@ -9,7 +9,7 @@
 #include <thread>
 #include <iomanip>
 
-#elif _WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
## Summary
- correct `#elif _WIN32` usage in MinerCore.cpp and JobManager.cpp

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68416c7c80ac8320a4e692d5cb4f9f5a